### PR TITLE
Flashcard display

### DIFF
--- a/app/components/FlashcardDisplay.tsx
+++ b/app/components/FlashcardDisplay.tsx
@@ -1,0 +1,110 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { flashcards as flashcardType, flashcardsResponse } from "@/types";
+import { Box, Image, Text, IconButton, Flex } from "@chakra-ui/react";
+import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
+
+const FlashcardDisplay = ({ id }: { id: string }) => {
+    const [flashcard, setFlashcard] = useState<flashcardType | null>(null);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchFlashcardData = async () => {
+            try {
+                const response = await fetch(`/api/flashcards/${id}`);
+                if (!response.ok) {
+                    throw new Error("Network error");
+                }
+                const data: flashcardsResponse = await response.json();
+                if (data.flashcards.length > 0) {
+                    setFlashcard(data.flashcards[0]);
+                } else {
+                    throw new Error("No flashcard found");
+                }
+            } catch (error: any) {
+                setError(error.message);
+            }
+        };
+        fetchFlashcardData();
+        console.log(flashcard);
+    }, [id]);
+
+    const handleNext = () => {
+        if (flashcard && currentIndex < flashcard.body.length) {
+            setCurrentIndex(currentIndex + 1);
+        }
+    };
+
+    const handlePrev = () => {
+        if (currentIndex > 0) {
+            setCurrentIndex(currentIndex - 1);
+        }
+    };
+
+    if (error) {
+        return (
+            <>
+                <div>Error: {error}</div>
+            </>
+        );
+    }
+
+    if (!flashcard) {
+        return (
+            <>
+                <div>Loading...</div>
+            </>
+        );
+    }
+
+    const isImageCard = currentIndex === 0;
+    const bodyContent = isImageCard ? (
+        <Image src={flashcard.img_url} alt={flashcard.title} />
+    ) : (
+        <Text>{flashcard.body[currentIndex - 1]}</Text>
+    );
+
+    return (
+        <>
+            <Flex justifyContent="center" alignItems="center" height="100vh">
+                <Box
+                    p={5}
+                    borderWidth="1px"
+                    borderRadius="2xl"
+                    overflow="hidden"
+                    width="300px"
+                    height="360px"
+                    position="relative"
+                >
+                    <Text fontSize="2xl" mb={4}>
+                        {flashcard.title}
+                    </Text>
+                    <Box height="80%" mb={10}>
+                        {bodyContent}
+                    </Box>
+                    <IconButton
+                        onClick={handlePrev}
+                        isDisabled={currentIndex === 0}
+                        icon={<ArrowBackIcon />}
+                        aria-label="Previous"
+                        position="absolute"
+                        left="0"
+                        bottom="0"
+                    />
+                    <IconButton
+                        onClick={handleNext}
+                        isDisabled={currentIndex === flashcard.body.length}
+                        icon={<ArrowForwardIcon />}
+                        aria-label="Next"
+                        position="absolute"
+                        right="0"
+                        bottom="0"
+                    />
+                </Box>
+            </Flex>
+        </>
+    );
+};
+
+export default FlashcardDisplay;

--- a/app/components/FlashcardDisplay.tsx
+++ b/app/components/FlashcardDisplay.tsx
@@ -108,8 +108,8 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                     borderWidth="1px"
                     borderRadius="2xl"
                     overflow="hidden"
-                    width="300px"
-                    height="360px"
+                    width="360px"
+                    height="380px"
                     position="relative"
                     bg={isCompleteCard ? "teal.50" : "white"}
                 >

--- a/app/components/FlashcardDisplay.tsx
+++ b/app/components/FlashcardDisplay.tsx
@@ -9,6 +9,7 @@ import {
     IconButton,
     Flex,
     Icon,
+    Progress,
 } from "@chakra-ui/react";
 import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
 import { FiBookmark, FiCheckCircle } from "react-icons/fi";
@@ -67,6 +68,9 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
         );
     }
 
+    const totalSteps = flashcard.body.length + 2;
+    const progressPercentage = (currentIndex / (totalSteps - 1)) * 100;
+
     const isImageCard = currentIndex === 0;
     const isCompleteCard = currentIndex === flashcard.body.length + 1;
     const bodyContent = isImageCard ? (
@@ -74,7 +78,7 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
             src={flashcard.img_url}
             alt={flashcard.title}
             objectFit="cover"
-            height="70%"
+            height="60%"
             width="100%"
             borderRadius="lg"
         />
@@ -107,7 +111,15 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                     width="300px"
                     height="360px"
                     position="relative"
+                    bg={isCompleteCard ? "teal.50" : "white"}
                 >
+                    <Progress
+                        value={progressPercentage}
+                        size="sm"
+                        colorScheme="teal"
+                        borderRadius="2xl"
+                        mb={4}
+                    />
                     <Text fontSize="2xl" mb={4}>
                         {flashcard.title}
                     </Text>

--- a/app/components/FlashcardDisplay.tsx
+++ b/app/components/FlashcardDisplay.tsx
@@ -11,8 +11,13 @@ import {
     Icon,
     Progress,
 } from "@chakra-ui/react";
-import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
-import { FiBookmark, FiCheckCircle } from "react-icons/fi";
+import {
+    FiArrowLeft,
+    FiArrowRight,
+    FiBookmark,
+    FiCheckCircle,
+    FiXCircle,
+} from "react-icons/fi";
 
 const FlashcardDisplay = ({ id }: { id: string }) => {
     const [flashcard, setFlashcard] = useState<flashcardType | null>(null);
@@ -88,7 +93,7 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                 Lesson Complete!
             </Text>
             <Flex justifyContent="center" direction="column" gap={4}>
-                <Button leftIcon={<Icon as={FiBookmark} />} variant="outline">
+                <Button leftIcon={<FiBookmark />} variant="outline">
                     Add to Bookmarks
                 </Button>
                 <Button leftIcon={<FiCheckCircle />} variant="solid">
@@ -113,14 +118,24 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                     position="relative"
                     bg={isCompleteCard ? "teal.50" : "white"}
                 >
+                    <IconButton
+                        icon={<FiXCircle />}
+                        aria-label="Close"
+                        position="absolute"
+                        top="0"
+                        left="0"
+                        m={2}
+                    />
                     <Progress
                         value={progressPercentage}
+                        width="80%"
+                        left="10"
                         size="sm"
                         colorScheme="teal"
                         borderRadius="2xl"
                         mb={4}
                     />
-                    <Text fontSize="2xl" mb={4}>
+                    <Text fontSize="2xl" mt={8} mb={4}>
                         {flashcard.title}
                     </Text>
                     <Box height="100%" mb={10}>
@@ -129,7 +144,7 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                     <IconButton
                         onClick={handlePrev}
                         isDisabled={currentIndex === 0}
-                        icon={<ArrowBackIcon />}
+                        icon={<FiArrowLeft />}
                         aria-label="Previous"
                         position="absolute"
                         left="0"
@@ -138,7 +153,7 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                     <IconButton
                         onClick={handleNext}
                         isDisabled={currentIndex === flashcard.body.length + 1}
-                        icon={<ArrowForwardIcon />}
+                        icon={<FiArrowRight />}
                         aria-label="Next"
                         position="absolute"
                         right="0"

--- a/app/components/FlashcardDisplay.tsx
+++ b/app/components/FlashcardDisplay.tsx
@@ -1,8 +1,17 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { flashcards as flashcardType, flashcardsResponse } from "@/types";
-import { Box, Image, Text, IconButton, Flex } from "@chakra-ui/react";
+import {
+    Box,
+    Image,
+    Text,
+    Button,
+    IconButton,
+    Flex,
+    Icon,
+} from "@chakra-ui/react";
 import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
+import { FiBookmark, FiCheckCircle } from "react-icons/fi";
 
 const FlashcardDisplay = ({ id }: { id: string }) => {
     const [flashcard, setFlashcard] = useState<flashcardType | null>(null);
@@ -31,7 +40,7 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
     }, [id]);
 
     const handleNext = () => {
-        if (flashcard && currentIndex < flashcard.body.length) {
+        if (flashcard && currentIndex <= flashcard.body.length) {
             setCurrentIndex(currentIndex + 1);
         }
     };
@@ -59,8 +68,30 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
     }
 
     const isImageCard = currentIndex === 0;
+    const isCompleteCard = currentIndex === flashcard.body.length + 1;
     const bodyContent = isImageCard ? (
-        <Image src={flashcard.img_url} alt={flashcard.title} />
+        <Image
+            src={flashcard.img_url}
+            alt={flashcard.title}
+            objectFit="cover"
+            height="70%"
+            width="100%"
+            borderRadius="lg"
+        />
+    ) : isCompleteCard ? (
+        <Box textAlign="center">
+            <Text fontSize="1xl" mb={4}>
+                Lesson Complete!
+            </Text>
+            <Flex justifyContent="center" direction="column" gap={4}>
+                <Button leftIcon={<Icon as={FiBookmark} />} variant="outline">
+                    Add to Bookmarks
+                </Button>
+                <Button leftIcon={<FiCheckCircle />} variant="solid">
+                    Mark as Complete
+                </Button>
+            </Flex>
+        </Box>
     ) : (
         <Text>{flashcard.body[currentIndex - 1]}</Text>
     );
@@ -80,7 +111,7 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                     <Text fontSize="2xl" mb={4}>
                         {flashcard.title}
                     </Text>
-                    <Box height="80%" mb={10}>
+                    <Box height="100%" mb={10}>
                         {bodyContent}
                     </Box>
                     <IconButton
@@ -94,7 +125,7 @@ const FlashcardDisplay = ({ id }: { id: string }) => {
                     />
                     <IconButton
                         onClick={handleNext}
-                        isDisabled={currentIndex === flashcard.body.length}
+                        isDisabled={currentIndex === flashcard.body.length + 1}
                         icon={<ArrowForwardIcon />}
                         aria-label="Next"
                         position="absolute"

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -2,7 +2,7 @@
 import NavBar from "@/app/components/NavBar";
 import { flashcards as flashcardType, flashcardsResponse } from "@/types";
 import React, { useEffect, useState } from "react";
-import { Box, Image, Text, VStack, Button, Flex } from "@chakra-ui/react";
+import { Box, Image, Text, Button, Flex } from "@chakra-ui/react";
 import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
 
 export default function Flashcard({ params }: { params: { id: string } }) {
@@ -78,6 +78,7 @@ export default function Flashcard({ params }: { params: { id: string } }) {
                     borderRadius="lg"
                     overflow="hidden"
                     width="300px"
+                    height="400px"
                 >
                     <Text fontSize="2xl" mb={4}>
                         {flashcard.title}
@@ -86,18 +87,16 @@ export default function Flashcard({ params }: { params: { id: string } }) {
                     <Flex mt={4} justifyContent="space-between">
                         <Button
                             onClick={handlePrev}
-                            disabled={currentIndex === 0}
+                            isDisabled={currentIndex === 0}
                             leftIcon={<ArrowBackIcon />}
-                        >
-                            Previous
-                        </Button>
+                            aria-label="Previous"
+                        ></Button>
                         <Button
                             onClick={handleNext}
-                            disabled={currentIndex === flashcard.body.length}
+                            isDisabled={currentIndex === flashcard.body.length}
                             rightIcon={<ArrowForwardIcon />}
-                        >
-                            Next
-                        </Button>
+                            aria-label="Next"
+                        ></Button>
                     </Flex>
                 </Box>
             </Flex>

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -1,105 +1,11 @@
-"use client";
+import FlashcardDisplay from "@/app/components/FlashcardDisplay";
 import NavBar from "@/app/components/NavBar";
-import { flashcards as flashcardType, flashcardsResponse } from "@/types";
-import React, { useEffect, useState } from "react";
-import { Box, Image, Text, Button, Flex } from "@chakra-ui/react";
-import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
 
 export default function Flashcard({ params }: { params: { id: string } }) {
-    const [flashcard, setFlashcard] = useState<flashcardType | null>(null);
-    const [currentIndex, setCurrentIndex] = useState(0);
-    const [error, setError] = useState<string | null>(null);
-
-    useEffect(() => {
-        const fetchFlashcardData = async () => {
-            try {
-                const response = await fetch(`/api/flashcards/${params.id}`);
-                if (!response.ok) {
-                    throw new Error("Network error");
-                }
-                const data: flashcardsResponse = await response.json();
-                if (data.flashcards.length > 0) {
-                    setFlashcard(data.flashcards[0]);
-                } else {
-                    throw new Error("No flashcard found");
-                }
-            } catch (error: any) {
-                setError(error.message);
-            }
-        };
-        fetchFlashcardData();
-        console.log(flashcard);
-    }, [params.id]);
-
-    const handleNext = () => {
-        if (flashcard && currentIndex < flashcard.body.length) {
-            setCurrentIndex(currentIndex + 1);
-        }
-    };
-
-    const handlePrev = () => {
-        if (currentIndex > 0) {
-            setCurrentIndex(currentIndex - 1);
-        }
-    };
-
-    if (error) {
-        return (
-            <>
-                <NavBar />
-                <div>Error: {error}</div>
-            </>
-        );
-    }
-
-    if (!flashcard) {
-        return (
-            <>
-                <NavBar />
-                <div>Loading...</div>
-            </>
-        );
-    }
-
-    const isImageCard = currentIndex === 0;
-    const bodyContent = isImageCard ? (
-        <Image src={flashcard.img_url} alt={flashcard.title} />
-    ) : (
-        <Text>{flashcard.body[currentIndex - 1]}</Text>
-    );
-
     return (
         <>
             <NavBar />
-            <Flex justifyContent="center" alignItems="center" height="100vh">
-                <Box
-                    p={5}
-                    borderWidth="1px"
-                    borderRadius="lg"
-                    overflow="hidden"
-                    width="300px"
-                    height="400px"
-                >
-                    <Text fontSize="2xl" mb={4}>
-                        {flashcard.title}
-                    </Text>
-                    {bodyContent}
-                    <Flex mt={4} justifyContent="space-between">
-                        <Button
-                            onClick={handlePrev}
-                            isDisabled={currentIndex === 0}
-                            leftIcon={<ArrowBackIcon />}
-                            aria-label="Previous"
-                        ></Button>
-                        <Button
-                            onClick={handleNext}
-                            isDisabled={currentIndex === flashcard.body.length}
-                            rightIcon={<ArrowForwardIcon />}
-                            aria-label="Next"
-                        ></Button>
-                    </Flex>
-                </Box>
-            </Flex>
+            <FlashcardDisplay id={params.id} />
         </>
     );
 }

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -2,9 +2,12 @@
 import NavBar from "@/app/components/NavBar";
 import { flashcards as flashcardType, flashcardsResponse } from "@/types";
 import React, { useEffect, useState } from "react";
+import { Box, Image, Text, VStack, Button, Flex } from "@chakra-ui/react";
+import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
 
 export default function Flashcard({ params }: { params: { id: string } }) {
     const [flashcard, setFlashcard] = useState<flashcardType | null>(null);
+    const [currentIndex, setCurrentIndex] = useState(0);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
@@ -28,6 +31,18 @@ export default function Flashcard({ params }: { params: { id: string } }) {
         console.log(flashcard);
     }, [params.id]);
 
+    const handleNext = () => {
+        if (flashcard && currentIndex < flashcard.body.length) {
+            setCurrentIndex(currentIndex + 1);
+        }
+    };
+
+    const handlePrev = () => {
+        if (currentIndex > 0) {
+            setCurrentIndex(currentIndex - 1);
+        }
+    };
+
     if (error) {
         return (
             <>
@@ -46,20 +61,46 @@ export default function Flashcard({ params }: { params: { id: string } }) {
         );
     }
 
+    const isImageCard = currentIndex === 0;
+    const bodyContent = isImageCard ? (
+        <Image src={flashcard.img_url} alt={flashcard.title} />
+    ) : (
+        <Text>{flashcard.body[currentIndex - 1]}</Text>
+    );
+
     return (
         <>
             <NavBar />
-            <div>
-                <h1>{flashcard.title}</h1>
-                <p>Section: {flashcard.section}</p>
-                <p>Unit: {flashcard.unit}</p>
-                <div>
-                    {flashcard.body.map((paragraph, index) => (
-                        <p key={index}>{paragraph}</p>
-                    ))}
-                </div>
-                <img src={flashcard.img_url} alt={flashcard.title} />
-            </div>
+            <Flex justifyContent="center" alignItems="center" height="100vh">
+                <Box
+                    p={5}
+                    borderWidth="1px"
+                    borderRadius="lg"
+                    overflow="hidden"
+                    width="300px"
+                >
+                    <Text fontSize="2xl" mb={4}>
+                        {flashcard.title}
+                    </Text>
+                    {bodyContent}
+                    <Flex mt={4} justifyContent="space-between">
+                        <Button
+                            onClick={handlePrev}
+                            disabled={currentIndex === 0}
+                            leftIcon={<ArrowBackIcon />}
+                        >
+                            Previous
+                        </Button>
+                        <Button
+                            onClick={handleNext}
+                            disabled={currentIndex === flashcard.body.length}
+                            rightIcon={<ArrowForwardIcon />}
+                        >
+                            Next
+                        </Button>
+                    </Flex>
+                </Box>
+            </Flex>
         </>
     );
 }

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+import NavBar from "@/app/components/NavBar";
+import { flashcards as flashcardType, flashcardsResponse } from "@/types";
+import React, { useEffect, useState } from "react";
+
+export default function Flashcard({ params }: { params: { id: string } }) {
+    const [flashcard, setFlashcard] = useState<flashcardType | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchFlashcardData = async () => {
+            try {
+                const response = await fetch(`/api/flashcards/${params.id}`);
+                if (!response.ok) {
+                    throw new Error("Network error");
+                }
+                const data: flashcardsResponse = await response.json();
+                if (data.flashcards.length > 0) {
+                    setFlashcard(data.flashcards[0]);
+                } else {
+                    throw new Error("No flashcard found");
+                }
+            } catch (error: any) {
+                setError(error.message);
+            }
+        };
+        fetchFlashcardData();
+        console.log(flashcard);
+    }, [params.id]);
+
+    if (error) {
+        return (
+            <>
+                <NavBar />
+                <div>Error: {error}</div>
+            </>
+        );
+    }
+
+    if (!flashcard) {
+        return (
+            <>
+                <NavBar />
+                <div>Loading...</div>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <NavBar />
+            <div>
+                <h1>{flashcard.title}</h1>
+                <p>Section: {flashcard.section}</p>
+                <p>Unit: {flashcard.unit}</p>
+                <div>
+                    {flashcard.body.map((paragraph, index) => (
+                        <p key={index}>{paragraph}</p>
+                    ))}
+                </div>
+                <img src={flashcard.img_url} alt={flashcard.title} />
+            </div>
+        </>
+    );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import {  AuthProvider } from "./providers";
+import { AuthProvider } from "./providers";
 import { fonts } from "./fonts";
 import "../app/globals.css";
 import React from "react";
+import { ChakraProvider } from "@chakra-ui/react";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -20,7 +21,9 @@ export default function RootLayout({
     return (
         <html lang="en" className={fonts.rubik.variable}>
             <body className={inter.className}>
-              <AuthProvider>{children}</AuthProvider>
+                <AuthProvider>
+                    <ChakraProvider>{children}</ChakraProvider>
+                </AuthProvider>
             </body>
         </html>
     );

--- a/types.ts
+++ b/types.ts
@@ -1,83 +1,87 @@
 import { ObjectId } from "mongodb";
 
 export class CustomError extends Error {
-  status: errorMsg
-  
-  constructor(msg: string, status: number) {
-    super(msg)
-    this.status = { code: status, msg}
-  }
+    status: errorMsg;
+
+    constructor(msg: string, status: number) {
+        super(msg);
+        this.status = { code: status, msg };
+    }
 }
 export interface errorMsg {
-  code: number,
-  msg: string
+    code: number;
+    msg: string;
 }
 
 export interface userResponse {
-  acknowledged: boolean;
-  insertedId: ObjectId;
-  _id: ObjectId;
-  username: string;
-  full_name: string;
-  email: string;
-  password: string;
-  bookmarks: number;
-  progress: Lesson[] | [];
+    acknowledged: boolean;
+    insertedId: ObjectId;
+    _id: ObjectId;
+    username: string;
+    full_name: string;
+    email: string;
+    password: string;
+    bookmarks: number;
+    progress: Lesson[] | [];
 }
 
 export interface comments {
-  _id: ObjectId;
-  author: string;
-  body: string;
-  votes: number;
-  date: Date;
+    _id: ObjectId;
+    author: string;
+    body: string;
+    votes: number;
+    date: Date;
 }
 
 export interface forums {
-  _id: ObjectId;
-  title: string;
-  body: string;
-  author: string;
-  votes: number;
-  date: Date;
-  comments: comments[];
+    _id: ObjectId;
+    title: string;
+    body: string;
+    author: string;
+    votes: number;
+    date: Date;
+    comments: comments[];
 }
 
 interface Lesson {
-  [key: `lesson${number}`]: boolean;
+    [key: `lesson${number}`]: boolean;
 }
 
 export interface users {
-  _id: ObjectId;
-  username: string;
-  full_name: string;
-  email: string;
-  password: string;
-  bookmarks: number;
-  progress: Lesson[];
+    _id: ObjectId;
+    username: string;
+    full_name: string;
+    email: string;
+    password: string;
+    bookmarks: number;
+    progress: Lesson[];
 }
 
 export interface flashcards {
-  _id: ObjectId;
-  unit: number;
-  section: string;
-  title: string;
-  body: string[];
-  img_url: string;
+    _id: ObjectId;
+    unit: number;
+    section: string;
+    title: string;
+    body: string[];
+    img_url: string;
+}
+
+export interface flashcardsResponse {
+    flashcards: flashcards[];
 }
 
 export interface articles {
-  _id: ObjectId;
-  title: string;
-  link: string;
-  img_url: string;
-  body: string;
-  source: string;
+    _id: ObjectId;
+    title: string;
+    link: string;
+    img_url: string;
+    body: string;
+    source: string;
 }
 
 export interface updateFields {
-  username?: string,
-  password?: string,
-  full_name?: string,
-  email?: string,
+    username?: string;
+    password?: string;
+    full_name?: string;
+    email?: string;
 }


### PR DESCRIPTION
## Setup / Config
- Brings in ChakraProvider to `layout.tsx` and wraps around children
- Adds flashcardsResponse to `types.ts`

## /flashcards/[id]

- Gets the id from params (currently referring to “unit” on the backend, so works for `/flashcards/1` (up to 5)
- Displays the `NavBar` and the `FlashcardDisplay` components

## FlashcardDisplay
- Brings in several Chakra components and icons from react-icons/fi - these can be changed as needed, but was going off what’s been used in the NavBar
- `flashcard`, `currentIndex` and `error` controlled with `useState`
- Fires off a fetch to `/api/flashcards/[id]` to set the flashcard data
- Display of image card and  lesson complete card handled with `currentIndex` and ternary operator
- Progress bar from Chakra with progress percentage derived from number of steps and `currentIndex`.
- Lesson complete card currently changing the background colour - just wanted to see if this would work - not sure if we want that to happen or not

##  Issues
- close, add to bookmarks and mark as complete buttons not currently functioning to do anything
- At the moment we have a get flashcards by unit on the backend. So currently this gets the flashcards by unit (there is currently only one per unit anyway) and displays the flashcard at index 0 of  the returned array. 
- Not sure if we want to implement a get flashcard by id, or somehow pass in the individual lesson data to this component from the progress path.
- Not very responsive in design, but I think it looks kind of ok at all sizes - currently the height and width are hardcoded.
- This does ensure consistent card size when clicking through which looks better than changing based on text length.
![Screenshot 2024-05-28 at 13 39 20](https://github.com/elliejaneeeeee/Parentify/assets/22136578/439db03a-8c30-4902-9234-6839b390d587)
![Screenshot 2024-05-28 at 13 39 31](https://github.com/elliejaneeeeee/Parentify/assets/22136578/eee10395-b33c-4f63-87b0-6a0a9b85765a)
![Screenshot 2024-05-28 at 13 39 42](https://github.com/elliejaneeeeee/Parentify/assets/22136578/713f26e8-b993-424c-a679-4cc934267d0b)

