### PR TITLE
Fixed bookmarks page load

### DIFF
--- a/app/components/BookmarksList.tsx
+++ b/app/components/BookmarksList.tsx
@@ -62,6 +62,7 @@ const BookmarksList = () => {
      
       <Text>{session?.user?.name}'s saved posts</Text>
       {bookmarksList.map((bookmark) => {
+        if (!bookmark) return null;
         if (bookmark.link) {
           return (
             <>


### PR DESCRIPTION
* Was erroring when an undefined article was returned, now checks whether it exists first and returns empty element if not